### PR TITLE
feat: Implement Return to Meet Home page

### DIFF
--- a/background.js
+++ b/background.js
@@ -18,10 +18,30 @@ const toggleMicrophone = function () {
   });
 };
 
+const redirectToMeetHome = () => {
+  chrome.tabs.query({ url: "https://meet.google.com/*" }, function (tabs) {
+    if (tabs && tabs.length > 0) {
+      tabs.forEach((tab) => {
+        chrome.tabs.sendMessage(tab.id, { returnHome: true });
+      });
+    }
+  });
+}
+
 chrome.commands.onCommand.addListener(function (command) {
-  // console.log("Command:", command);
-  toggleMicrophone();
+  // console.log('Command', command);
+  switch (command) {
+    case 'toggle-mic':  
+      toggleMicrophone();
+      break;
+    case 'return-home':
+      redirectToMeetHome();
+      break;
+    default:
+      break;
+  }
 });
+
 
 // chrome.tabs.onUpdated is called when a tab is updated in chrome
 // For meet, when the user joins a call, chrome.tabs.onUpdated is called with the changeInfo as

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   "content_scripts": [
     {
       "matches": ["https://meet.google.com/*"],
-      "js": ["togglemic.js"]
+      "js": ["togglemic.js", "returnToMeetHome.js"]
     }
   ],
   "commands": {
@@ -21,6 +21,13 @@
       },
       "description": "Toggle Microphone",
       "global": true
+    }, 
+    "return-home": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+1"
+      },
+      "description": "Return to Meet Home",
+      "global": false
     }
   },
   "browser_action": {

--- a/returnToMeetHome.js
+++ b/returnToMeetHome.js
@@ -1,0 +1,13 @@
+window.addEventListener(
+    "load",
+    function () {
+      chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+        if(request.returnHome){
+            window.location.href = "https://meet.google.com";
+        }
+        return true;
+      });
+    },
+    false
+  );
+  


### PR DESCRIPTION
- Add command for Ctrl+Shift+1
- Add content script returnToMeetHome.js
- Redirect all Meet windows to Meet home page.
- Currently set global to false. Not a global shortcut. 

![meetReturnHome](https://user-images.githubusercontent.com/17728976/87252397-4fb7c600-c490-11ea-8c86-ff6a219c9dc4.gif)
