### PR TITLE
feat: Implement switching to active meet tab

### DIFF
--- a/background.js
+++ b/background.js
@@ -28,6 +28,18 @@ const redirectToMeetHome = () => {
   });
 }
 
+const switchToActiveTab = () => {
+  chrome.tabs.query({ url: "https://meet.google.com/*" }, function (tabs) {
+    tabs.forEach((tab) => {
+      chrome.tabs.sendMessage(tab.id, { checkActiveMeetCall: true }, (response) => {
+        if(response.shouldSwitchToThisTab){
+          chrome.tabs.update(tab.id, {selected: true});
+        }
+      });
+    });
+  });
+}
+
 chrome.commands.onCommand.addListener(function (command) {
   // console.log('Command', command);
   switch (command) {
@@ -36,6 +48,9 @@ chrome.commands.onCommand.addListener(function (command) {
       break;
     case 'return-home':
       redirectToMeetHome();
+      break;
+    case 'switch-to-active-tab':
+      switchToActiveTab();
       break;
     default:
       break;
@@ -48,7 +63,7 @@ chrome.commands.onCommand.addListener(function (command) {
 // { 'audible': 'false' }
 // Using that as a trigger send a message to content script, to start listening for click events
 chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  // console.log("Tab updated", tabId, changeInfo, tab);
+  console.log("Tab updated", tabId, changeInfo, tab);
   if ((changeInfo.status === "complete" && tab.url !== "https://meet.google.com/") || changeInfo.audible === false) {
     chrome.tabs.query({ url: "https://meet.google.com/*" }, function (tabs) {
       if (tabs && tabs.length > 0) {

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   "content_scripts": [
     {
       "matches": ["https://meet.google.com/*"],
-      "js": ["togglemic.js", "returnToMeetHome.js"]
+      "js": ["togglemic.js", "returnToMeetHome.js", "switchToActiveTab.js"]
     }
   ],
   "commands": {
@@ -28,6 +28,13 @@
       },
       "description": "Return to Meet Home",
       "global": false
+    }, 
+    "switch-to-active-tab": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+2"
+      },
+      "description": "Switch to active Meet tab",
+      "global": true
     }
   },
   "browser_action": {

--- a/switchToActiveTab.js
+++ b/switchToActiveTab.js
@@ -1,0 +1,21 @@
+const closeButtonClassName = 's1GInc zCbbgf';
+window.addEventListener(
+    "load",
+    function () {
+      chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+        if(request.checkActiveMeetCall){
+            let callCloseButtonCount = document.getElementsByClassName(closeButtonClassName).length;
+            if(callCloseButtonCount < 1){
+                return true;
+            } else {
+                sendResponse({
+                    shouldSwitchToThisTab: true
+                })
+            }
+        }
+        return true;
+      });
+    },
+    false
+  );
+  


### PR DESCRIPTION
Switch to active meet tab.
- Iterate through the list of tabs with meet.google.com
- Look for the tab which contains *Close* button
- Switch to that tab using chrome.tabs.update