### PR TITLE
Feature/disable notifications

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,5 @@
 chrome.runtime.onInstalled.addListener(function (details) {
-  console.log("Google Meet PTT Installed");
+  // console.log("Google Meet PTT Installed");
   switch (details.reason) {
     case 'install':
       let previousMicState = "ON";
@@ -58,23 +58,23 @@ const switchToActiveTab = () => {
 }
 
 const toogleNotifications = () => {
-  chrome.storage.local.get('notifications', function (notifications) {
-    let notificationText = notifications === true ? "Enabled" : "Disabled";
-    chrome.notifications.create('notify1', opt, function() { console.log('created!'); });
+  chrome.storage.local.get('notifications', function (val) {
+    let currentEnabled = val.notifications === true || val.notifications === undefined;
+    let notificationText = currentEnabled ? "Disabled" : "Enabled";
+    chrome.storage.local.set({notifications: !currentEnabled });
+
     chrome.notifications.create({
       title: "Mute for Google Meet™",
       type: "basic",
-      // iconUrl: `icons/meet_assist_default.png`,
+      iconUrl: `icons/meet_assist_default.png`,
       message: `${notificationText} mic notifications`,
       silent: true,
     });
-    notifications = notifications === true ? false : true ;
-    chrome.storage.local.set({notifications});
   });
 }
 
 chrome.commands.onCommand.addListener(function (command) {
-  // console.log('Command', command);
+  //console.log('Command', command);
   let notifications;
   switch (command) {
     case 'toggle-mic':  
@@ -129,7 +129,7 @@ chrome.runtime.onMessage.addListener(function (request, sender) {
         chrome.notifications.create({
           title: "Mute for Google Meet™",
           type: "basic",
-          iconUrl: `icons/mic-${request.micMuted}.svg`,
+          iconUrl: chrome.runtime.getURL(`icons/mic-${request.micMuted}.png`), //.svg dont work for me :(
           message: `Mic is ${request.micMuted}`,
           silent: true,
         });

--- a/manifest.json
+++ b/manifest.json
@@ -1,50 +1,55 @@
 {
-  "name": "Mute for Google Meet™",
-  "version": "1.0.2",
-  "description": "Universal mute toggle for Google Meet",
-  "manifest_version": 2,
-  "background": {
-    "scripts": ["background.js"],
-    "persistent": false
-  },
-  "permissions": ["tabs", "https://meet.google.com/*", "notifications"],
-  "content_scripts": [
-    {
-      "matches": ["https://meet.google.com/*"],
-      "js": ["togglemic.js", "returnToMeetHome.js", "switchToActiveTab.js"]
-    }
-  ],
-  "commands": {
-    "toggle-mic": {
-      "suggested_key": {
-        "default": "Ctrl+Shift+5"
-      },
-      "description": "Toggle Microphone",
-      "global": true
-    }, 
-    "return-home": {
-      "suggested_key": {
-        "default": "Ctrl+Shift+1"
-      },
-      "description": "Return to Meet Home",
-      "global": false
-    }, 
-    "switch-to-active-tab": {
-      "suggested_key": {
-        "default": "Ctrl+Shift+2"
-      },
-      "description": "Switch to active Meet tab",
-      "global": true
-    }
-  },
-  "browser_action": {
-    "default_icon": {
-      "32": "icons/meet_assist_default.png"
-    }
-  },
-  "icons": {
-    "16": "icons/meet_assist_16.png",
-    "48": "icons/meet_assist_48.png",
-    "128": "icons/meet_assist_128.png"
-  }
+	"name": "Mute for Google Meet™",
+	"version": "1.1.0",
+	"description": "Universal mute toggle for Google Meet",
+	"manifest_version": 3,
+	"background": {
+		"service_worker": "background.js"
+	},
+	"permissions": ["tabs", "notifications", "storage"],
+	"host_permissions": ["https://meet.google.com/*"],
+	"content_scripts": [{
+		"matches": ["https://meet.google.com/*"],
+		"js": ["togglemic.js", "returnToMeetHome.js", "switchToActiveTab.js"]
+	}],
+	"commands": {
+		"toggle-mic": {
+			"suggested_key": {
+				"default": "Ctrl+Shift+5"
+			},
+			"description": "Toggle Microphone",
+			"global": true
+		},
+		"return-home": {
+			"suggested_key": {
+				"default": "Ctrl+Shift+1"
+			},
+			"description": "Return to Meet Home",
+			"global": false
+		},
+		"switch-to-active-tab": {
+			"suggested_key": {
+				"default": "Ctrl+Shift+2"
+			},
+			"description": "Switch to active Meet tab",
+			"global": true
+		},
+		"toogle-notifications": {
+			"suggested_key": {
+				"default": "Ctrl+Shift+9"
+			},
+			"description": "Enable/Disable notifications",
+			"global": false
+		}
+	},
+	"action": {
+		"default_icon": {
+			"32": "icons/meet_assist_default.png"
+		}
+	},
+	"icons": {
+		"16": "icons/meet_assist_16.png",
+		"48": "icons/meet_assist_48.png",
+		"128": "icons/meet_assist_128.png"
+	}
 }

--- a/manifest.json
+++ b/manifest.json
@@ -36,7 +36,7 @@
 		},
 		"toogle-notifications": {
 			"suggested_key": {
-				"default": "Ctrl+Shift+9"
+				"default": "Ctrl+Shift+8"
 			},
 			"description": "Enable/Disable notifications",
 			"global": false


### PR DESCRIPTION
Hi @mahadevans87 I make same changes for my use. 
I dont like the notifications, but the extension works very well.

- Option to disable notifications (shortcut to enable/disable notifications)
- change manifest to V3
PS: the 'Switch to active Meet tab' dont work any more... include the 1.0.2 version

Tanks for your extension